### PR TITLE
Bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stevefan1999/babel-plugin-transform-pug-html",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Transforms \"pug\" tagged template literals into html strings",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Yarn seems to get confused about cache resolution when multiple resolutions of the package exist with the same version.

Deliberately bump to a version that doesn't exist on npm to avoid any confusion.